### PR TITLE
Switch to distroless image and don't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM scratch
-#COPY ui/build/ /build
-#COPY ui/index.html /
-#ENV ZONEINFO=/zoneinfo.zip
-#COPY zoneinfo.zip /
+FROM gcr.io/distroless/static-debian11:nonroot
 COPY config-reloader /
+USER nonroot
 ENTRYPOINT ["/config-reloader"]


### PR DESCRIPTION
- distroless is smaller images and more secure than alpine, it's a perfect fit for static go apps
- with nonroot tag of distroless images we get a nonroot user ready to be used with the container, so use this user so we don't run as root when not needed

ref: https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md